### PR TITLE
Add custom error handling support (fixes #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ __It is also possible to set configuration variables, these are them:__
 |`logLevel` | `String` | Possible values from less to more level of verbosity are: error, warning, custom, info and debug. Ignored if `customLogger` is used. Default is info. |
 |`logFile` | `String` | Logs file path. Ignored if `customLogger` is used. |
 |`customLogger` | `Object` | Replaces the included logger with the one specified here, so that you can reuse your own logger. `logLevel` and `logFile` will be ignored if this variable is used. Null by default. |
+|`customErrorHandling` | `Boolean` | Indicates if there should be a direct response (`false`) or `next()` should be called for custom error handling |
 |`controllers` | `String` | Controllers location path. |
 |`checkControllers` | `Boolean` | Checks if controllers exist for all specified methods. True by default. |
 |`strict`	| `Boolean` | Indicates whether validation must stop the request process if errors were found when validating according to specification file. false by default. |
@@ -513,6 +514,15 @@ Since oas-tools reports validation errors with a common structure, we provide a 
   }
 }
 ```
+
+By default, the errors are returned by a direct HTTP 400 response. If you need custom error handling, you may set the `customErrorHandling` config property to `true`, 
+which causes validation errors to be passed to `next()`. The following properties are set:
+
+| Name	| Type	| Explanation / Values |
+| ------------- | ------------- | ------------- |
+|`failedValidation` | `Boolean` | Property can be used to check if the error comes from the oas validation. |
+|`validationResult` | `Object` | Validation results conforming to the beforementioned schema. |
+ 
 
 ## License
 

--- a/src/configurations/configs.yaml
+++ b/src/configurations/configs.yaml
@@ -5,6 +5,7 @@ production:
   loglevel: info
   #logfile: './logs/pro-logs.log'
   customLogger: null
+  customErrorHandling: false
   strict: false
   router: true
   validator: true
@@ -24,6 +25,7 @@ development:
   loglevel: debug
   #logfile: './dev-logs.log' #if dir is specified before file and that dir doesnt exist: EXCEPTION! winston can create file but not folder
   customLogger: null
+  customErrorHandling: false
   strict: true
   router: true
   validator: true

--- a/src/middleware/oas-validator.js
+++ b/src/middleware/oas-validator.js
@@ -75,7 +75,7 @@ function filterParams(methodParameters, pathParameters) {
 /**
  * transfer fieldname(s) and filename(s) of an multipart/form-data request to a data object
  * that is subsequently passed to a validator checking for required properties of a openAPI path operation
- * 
+ *
  * @param {array} files
  * @param {object} dataToValidate
  * @returns {object}
@@ -114,7 +114,7 @@ function checkRequestData(oasDoc, requestedSpecPath, method, res, req, next) { /
         keepGoing = false;
       } else {
         // can be any of "application/json", "multipart/form-data", "image/png", ...
-        const contentType = Object.keys(requestBody.content)[0]; 
+        const contentType = Object.keys(requestBody.content)[0];
         var validSchema = requestBody.content[contentType].schema;
         var data = req.body; //JSON.parse(req.body); //Without this everything is string so type validation wouldn't happen TODO: why is it commented?
         // a multipart/form-data request has a "files" property in the request whose
@@ -189,8 +189,17 @@ function checkRequestData(oasDoc, requestedSpecPath, method, res, req, next) { /
     }
   }
   if (keepGoing == false && config.strict == true) {
-    logger.error(JSON.stringify(msg));
-    res.status(400).send(msg);
+    if (config.customErrorHandling) {
+      var error = new Error('Request validation error')
+      Object.assign(error, {
+        failedValidation: true,
+        validationResult: msg
+      })
+      next(error)
+    } else {
+      logger.error(JSON.stringify(msg));
+      res.status(400).send(msg);
+    }
   } else {
     if (msg.length != 0) {
       logger.warning(JSON.stringify(msg));
@@ -422,7 +431,7 @@ module.exports = (oasDoc) => {
 
     var requestBody = oasDoc.paths[requestedSpecPath][method].requestBody;
     if (requestBody != undefined) {
-      // when and endpoint provides a file upload option and other properties, 
+      // when and endpoint provides a file upload option and other properties,
       // the content type changes to multipart/form-data
       // other requestBody types such as "image/png" are allowed as well
       // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#considerations-for-file-uploads
@@ -433,7 +442,7 @@ module.exports = (oasDoc) => {
         originalValue: req.body,
         value: req.body
       }
-      
+
       // inject possible file uploads
       if(contentType.toLowerCase() === 'multipart/form-data' && req.files && req.files.length > 0) {
         req.swagger.params[requestBody['x-name']].files = req.files;


### PR DESCRIPTION
Via the config property `customErrorMessages`, the validation handling can be changed so that instead of a direct HTTP 400 response, next is called with an Error having two properties `failedValidation: true` and the errors list in `validationResult`.