### PR TITLE
Avoid failing schema validation for objects with keys whose value is 'undefined'

### DIFF
--- a/tests/basic.js
+++ b/tests/basic.js
@@ -592,8 +592,7 @@ function getTests() {
         it('it should GET a pet by the given id', (done) => {
             var pet = {
                 id: 10,
-                name: "Pig",
-                tag: "Looking for mud"
+                name: "Pig"
             };
             chai.request(server)
                 .get('/api/v1/pets/' + pet.id)
@@ -606,10 +605,9 @@ function getTests() {
                     res.body.should.be.a('object');
                     res.body.should.have.property('id');
                     res.body.should.have.property('name');
-                    res.body.should.have.property('tag');
+                    res.body.should.not.have.property('tag');
                     res.body.should.have.property('id').eql(pet.id);
                     res.body.should.have.property('name').eql(pet.name);
-                    res.body.should.have.property('tag').eql(pet.tag);
                     done();
                 });
         });

--- a/tests/testServer/controllers/DefaultService.js
+++ b/tests/testServer/controllers/DefaultService.js
@@ -19,7 +19,7 @@ let pets = [
   {
     id: 10,
     name: "Pig",
-    tag: "Looking for mud"
+    tag: undefined
   },
   {
     id: 28,
@@ -53,7 +53,7 @@ function corruptPets() {
     {
       id: 10,
       name: "Pig",
-      tag: "Looking for mud"
+      tag: undefined
     },
     {
       name: "Bat",
@@ -93,7 +93,7 @@ function setCorrectPets() {
     {
       id: 10,
       name: "Pig",
-      tag: "Looking for mud"
+      tag: undefined
     },
     {
       id: 200,

--- a/tests/testServer/controllers/petsController.js
+++ b/tests/testServer/controllers/petsController.js
@@ -19,7 +19,7 @@ var pets = [
   {
     id: 10,
     name: "Pig",
-    tag: "Looking for mud"
+    tag: undefined
   },
   {
     id: 28,
@@ -94,7 +94,7 @@ function setCorrectPets() {
     {
       id: 10,
       name: "Pig",
-      tag: "Looking for mud"
+      tag: undefined
     },
     {
       id: 200,


### PR DESCRIPTION
When an object carries keys whose values are "undefined" they fail the z-schema validation even though those keys are optional in the schema and when the object is serialized to JSON the JSON serializes does not serializes "key": undefined, but it simply skips it, which makes the result actually fit the schema. The fix is to delete the undefined keys from the object.