### PR TITLE
Optional config docs prefix properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -367,7 +367,7 @@ function registerPaths(specDoc, app) {
     });
     if (config.docs.swaggerUi) {
       var uiHtml = fs.readFileSync(pathModule.join(__dirname, '../swagger-ui/index.html'), 'utf8');
-      uiHtml = uiHtml.replace('url: "/api-docs"', 'url: "' + config.docs.apiDocsPrefix + config.docs.apiDocs + '"');
+      uiHtml = uiHtml.replace(/url: "[^"]*"/, 'url: "' + config.docs.apiDocsPrefix + config.docs.apiDocs + '"');
       fs.writeFileSync(pathModule.join(__dirname, '../swagger-ui/index.html'), uiHtml, 'utf8');
       if (!config.docs.swaggerUiPrefix) {
         config.docs.swaggerUiPrefix = '';

--- a/src/index.js
+++ b/src/index.js
@@ -289,7 +289,7 @@ function registerPaths(specDoc, app) {
   };
   var OASValidatorMid = function() {
     var OASValidator = require('./middleware/oas-validator');
-    return OASValidator.call(undefined, specDoc); 
+    return OASValidator.call(undefined, specDoc);
   };
   initializeSecurityAndAuth(specDoc);
   var OASSecurityMid = function() {
@@ -359,6 +359,9 @@ function registerPaths(specDoc, app) {
     }
   }
   if (config.docs && config.docs.apiDocs) {
+    if (!config.docs.apiDocsPrefix) {
+      config.docs.apiDocsPrefix = '';
+    }
     app.use(config.docs.apiDocsPrefix + config.docs.apiDocs, function (req, res) {
       res.send(specDoc);
     });
@@ -366,6 +369,9 @@ function registerPaths(specDoc, app) {
       var uiHtml = fs.readFileSync(pathModule.join(__dirname, '../swagger-ui/index.html'), 'utf8');
       uiHtml = uiHtml.replace('url: "/api-docs"', 'url: "' + config.docs.apiDocsPrefix + config.docs.apiDocs + '"');
       fs.writeFileSync(pathModule.join(__dirname, '../swagger-ui/index.html'), uiHtml, 'utf8');
+      if (!config.docs.swaggerUiPrefix) {
+        config.docs.swaggerUiPrefix = '';
+      }
       app.use(config.docs.swaggerUiPrefix + config.docs.swaggerUi, express.static(pathModule.join(__dirname, '../swagger-ui')));
     }
   }


### PR DESCRIPTION
This PR addresses two concerns :

1. Same as PR https://github.com/isa-group/oas-tools/pull/138 but in a much simple way -

It is all about convention over configuration. If `config.docs.*Prefix` isn't provided, fallback to an empty string

2. When I have configures my docs [with `/api.json` for apiDocs for instance], I cannot change it because in **oas-tools/swagger-ui/index.html**, there will be no line matching THE STRING TO BE REPLACED: `url: "/api-docs"`

I propose to FIX it with a regular expression: `/url: "[^"]*"/`

Thank you.

PS: I cross everything for "Codecov Report" tests to pass