### PR TITLE
Fix hidden pre-runtime errors in controllers

### DIFF
--- a/src/middleware/oas-router.js
+++ b/src/middleware/oas-router.js
@@ -241,13 +241,7 @@ module.exports = (controllers) => {
 
     var opID = getOpId(oasDoc, requestedSpecPath, method);
 
-    try {
-      var controller = require(path.join(controllers, controllerName));
-    } catch (err) {
-      var errMsg = "Controller not found: " + path.join(controllers, controllerName);
-      logger.error(errMsg);
-      throw new Error(errMsg);
-    }
+    var controller = require(path.join(controllers, controllerName));
 
     var oldSend = res.send;
     res.send = function (data) { // eslint-disable-line


### PR DESCRIPTION
Fixed https://github.com/isa-group/oas-tools/issues/167 by removing the try-catch block when requiring controllers.
I do not explicitly check for file existence, because require() will throw an error anyway.

Let me know if any changes are required for this PR.