### PR TITLE
Keep a frozen copy oy of `specDoc` to respond to `/api` calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,8 +362,11 @@ function registerPaths(specDoc, app) {
     if (!config.docs.apiDocsPrefix) {
       config.docs.apiDocsPrefix = '';
     }
+
+    const apiSpecDoc = Object.freeze(_.cloneDeep(specDoc))
+
     app.use(config.docs.apiDocsPrefix + config.docs.apiDocs, function (req, res) {
-      res.send(specDoc);
+      res.send(apiSpecDoc);
     });
     if (config.docs.swaggerUi) {
       var uiHtml = fs.readFileSync(pathModule.join(__dirname, '../swagger-ui/index.html'), 'utf8');

--- a/src/middleware/oas-router.js
+++ b/src/middleware/oas-router.js
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
 
 var exports; // eslint-disable-line
 var path = require('path');
-var _ = require('lodash-compat')
 var ZSchema = require("z-schema");
 var MIMEtype = require('whatwg-mimetype');
 var config = require('../configurations'),
@@ -141,7 +140,7 @@ function checkResponse(req, res, oldSend, oasDoc, method, requestedSpecPath, con
     }
     if (resultType && resultType.essence === 'application/json') {
       //if there is no content property for the given response then there is nothing to validate.
-      var validSchema = _.cloneDeep(responseCodeSection.content['application/json'].schema);
+      var validSchema = responseCodeSection.content['application/json'].schema;
       utils.fixNullable(validSchema)
 
       content[0] = JSON.stringify(content[0]);


### PR DESCRIPTION
Fixes #186 
