### PR TITLE
Do not try to strip Buffer data

### DIFF
--- a/src/middleware/oas-router.js
+++ b/src/middleware/oas-router.js
@@ -57,7 +57,7 @@ function getExpectedResponse(responses, code) {
  * @param maxDepth limits the recursion to avoid stack overflow when object references itself
  */
 function stripUndefinedKeys(data, maxDepth = 1024) {
-  if (typeof data !== 'object' || data === null || maxDepth <= 0) {
+  if (typeof data !== 'object' || data === null || maxDepth <= 0 || data instanceof Buffer) {
     return data;
   }
   Object.getOwnPropertyNames(data).forEach((property) => {


### PR DESCRIPTION
No need to modify Buffer data. Sending files to client node can fail with: JavaScript heap out of memory