### PR TITLE
fixing #193 - use 'default' and 'example' params with 'null' value gave TypeError on fixNullable method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pids
 *.seed
 *.pid.lock
 
+.idea/
 .vscode/
 .logs/
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,10 +24,10 @@ var validator = require('validator');
 
 var fixNullable = function(schema) {
   Object.getOwnPropertyNames(schema).forEach((property) => {
-    if (typeof schema[property] === 'object' && schema[property] !== null) {
-      fixNullable(schema[property]);
-    } else if (property === 'type' && typeof schema[property] === 'string' && schema.nullable === true) {
+    if (property === 'type' && schema.nullable === true) {
       schema.type = [schema.type, "null"];
+    } else if (typeof schema[property] === 'object' && schema[property] !== null) {
+      fixNullable(schema[property]);
     }
   });
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,7 +24,9 @@ var validator = require('validator');
 
 var fixNullable = function(schema) {
   Object.getOwnPropertyNames(schema).forEach((property) => {
-    if (typeof schema[property] === 'object') {
+    if (schema[property] === null) {
+      schema.type = [schema.type, "null"];
+    } else if (typeof schema[property] === 'object') {
       fixNullable(schema[property]);
     } else if (property === 'type' && typeof schema[property] === 'string' && schema.nullable === true) {
       schema.type = [schema.type, "null"];

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,9 +24,7 @@ var validator = require('validator');
 
 var fixNullable = function(schema) {
   Object.getOwnPropertyNames(schema).forEach((property) => {
-    if (schema[property] === null) {
-      schema.type = [schema.type, "null"];
-    } else if (typeof schema[property] === 'object') {
+    if (typeof schema[property] === 'object' && schema[property] !== null) {
       fixNullable(schema[property]);
     } else if (property === 'type' && typeof schema[property] === 'string' && schema.nullable === true) {
       schema.type = [schema.type, "null"];

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -26,7 +26,7 @@ const serverProto = require('./testServer');
 let server = require('./testServer');
 const indexFile = require('./../src/index');
 const utilsFile = require('./../src/lib/utils');
-chai.should();
+const should = chai.should();
 chai.use(chaiHttp);
 var expect = chai.expect;
 const auxRequire = require('./testServer/controllers/petsController');
@@ -525,7 +525,13 @@ function getTests() {
                     }
                     res.should.have.status(200);
                     res.body.should.be.a('object');
-                    JSON.stringify(res.body).should.contain('null');
+                    should.not.exist(res.body.text);
+                    should.not.exist(res.body.active);
+                    should.not.exist(res.body.previousId);
+                    should.not.exist(res.body.colors);
+                    should.not.exist(res.body.contacts);
+                    should.not.exist(res.body.salary);
+                    should.not.exist(res.body.status);
                     done();
                 });
         });

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -518,7 +518,8 @@ function getTests() {
 
         it('it should get a sample response with a nullable field', (done) => {
             chai.request(server)
-                .get('/api/v1/nullableResponseTest')
+                .post('/api/v1/nullableResponseTest')
+                .send({id: 123})
                 .end((err, res) => {
                     if (err) {
                         done(err);

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -526,13 +526,7 @@ function getTests() {
                     }
                     res.should.have.status(200);
                     res.body.should.be.a('object');
-                    should.not.exist(res.body.text);
-                    should.not.exist(res.body.active);
-                    should.not.exist(res.body.previousId);
-                    should.not.exist(res.body.colors);
-                    should.not.exist(res.body.contacts);
-                    should.not.exist(res.body.salary);
-                    should.not.exist(res.body.status);
+                    should.equal(res.body.text, null);
                     done();
                 });
         });

--- a/tests/testServer/api/oai-spec.yaml
+++ b/tests/testServer/api/oai-spec.yaml
@@ -570,6 +570,8 @@ paths:
                   text:
                     type: string
                     nullable: true
+                    default: null
+                    example: null
       x-router-controller: "petsController"
   /defaultResponseCode:
     get:

--- a/tests/testServer/api/oai-spec.yaml
+++ b/tests/testServer/api/oai-spec.yaml
@@ -551,12 +551,70 @@ paths:
                 type: object
       x-router-controller: "petsController"
   /nullableResponseTest:
-    get:
+    post:
       summary: Nullable test
       operationId: nullableResponse
       security: []
       tags:
         - pets
+      requestBody:
+        description: Pet to add to the store
+        x-name: pet
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+              properties:
+                id:
+                  type: integer
+                lol:
+                  type: integer
+                  example: 444
+                  default: 444
+                aStringNullParam:
+                  description: a nullable string parameter
+                  type: string
+                  nullable: true
+                  default: null
+                  example: null
+                aBooleanNullParam:
+                  description: a nullable boolean parameter
+                  type: boolean
+                  nullable: true
+                  default: null
+                  example: null
+                anIntegerNullParam:
+                  description: a nullable integer parameter
+                  type: integer
+                  nullable: true
+                  default: null
+                  example: null
+                anArrayNullParam:
+                  description: a nullable array parameter
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
+                  default: null
+                  example: null
+                anObjectNullParam:
+                  description: a nullable object parameter
+                  type: object
+                  nullable: true
+                  default: null
+                  example: null
+                anEnumNullParam:
+                  description: a nullable enum parameter
+                  type: string
+                  nullable: true
+                  default: null
+                  example: null
+                  enum:
+                    - open
+                    - closed
+                    - null
       responses:
         '200':
           description: A sample response
@@ -580,6 +638,8 @@ paths:
                     default: null
                   colors:
                     type: array
+                    items:
+                      type: string
                     nullable: true
                   contacts:
                     type: object

--- a/tests/testServer/api/oai-spec.yaml
+++ b/tests/testServer/api/oai-spec.yaml
@@ -570,8 +570,31 @@ paths:
                   text:
                     type: string
                     nullable: true
-                    default: null
                     example: null
+                  active:
+                    type: boolean
+                    nullable: true
+                  previousId:
+                    type: integer
+                    nullable: true
+                    default: null
+                  colors:
+                    type: array
+                    nullable: true
+                  contacts:
+                    type: object
+                    nullable: true
+                    example: null
+                  salary:
+                    type: number
+                    nullable: true
+                  status:
+                    type: string
+                    nullable: true
+                    enum:
+                      - open
+                      - closed
+                      - null
       x-router-controller: "petsController"
   /defaultResponseCode:
     get:

--- a/tests/testServer/controllers/petsController.js
+++ b/tests/testServer/controllers/petsController.js
@@ -440,13 +440,7 @@ exports.wrongResponseCode = (req, res) => {
 exports.nullableResponse = (req, res) => {
   res.send({
     id: 123,
-    text: null,
-    active: null,
-    previousId: null,
-    colors: null,
-    contacts: null,
-    salary: null,
-    status: null
+    text: null
   });
 };
 

--- a/tests/testServer/controllers/petsController.js
+++ b/tests/testServer/controllers/petsController.js
@@ -440,7 +440,13 @@ exports.wrongResponseCode = (req, res) => {
 exports.nullableResponse = (req, res) => {
   res.send({
     id: 123,
-    text: null
+    text: null,
+    active: null,
+    previousId: null,
+    colors: null,
+    contacts: null,
+    salary: null,
+    status: null
   });
 };
 


### PR DESCRIPTION
Trying to solve the `TypeError: Cannot convert undefined or null to object` that occurs while using default or example field with "null" as value (normally used only when nullable is set to true)