### PR TITLE
Bugfix: Allow oas-validator to handle HTTP header parameters case-insensitively

### DIFF
--- a/src/middleware/oas-validator.js
+++ b/src/middleware/oas-validator.js
@@ -159,6 +159,10 @@ function checkRequestData(oasDoc, requestedSpecPath, method, res, req, next) { /
         var value;
 
         location = locationFormat(location);
+        if (location === "headers") {
+            name = name.toLowerCase(); // Allows OpenAPI Spec header params to be handled as case-insensitive.
+        }
+
         if (req[location][name] == undefined) { //if the request is missing a required parameter acording to the oasDoc: warning
           newErr = {
             message: "Missing parameter " + name + " in " + location + ". "

--- a/tests/testServer/api/oai-spec.yaml
+++ b/tests/testServer/api/oai-spec.yaml
@@ -292,6 +292,13 @@ paths:
       operationId: createPets
       tags:
         - pets
+      parameters:
+        - name: Authorization
+          schema:
+            type: string
+          in: header
+          description: "Authorization header paramter must be set using the form Bearer [token]."
+          required: True
       requestBody:
         description: Pet to add to the store
         x-name: pet

--- a/tests/testServer/api/oai-spec.yaml
+++ b/tests/testServer/api/oai-spec.yaml
@@ -297,7 +297,7 @@ paths:
           schema:
             type: string
           in: header
-          description: "Authorization header paramter must be set using the form Bearer [token]."
+          description: "Authorization header parameter must be set using the form Bearer [token]."
           required: True
       requestBody:
         description: Pet to add to the store


### PR DESCRIPTION
HTTP header parameter names are supposed to be case-insensitive.  This pull request allows oas-tools to treat header parameter names as case-insensitive.

Currently, if a header parameter called `Authorization` is marked `required: true` in an OpenAPI spec, the oas-tools strict validator fails to find that header. You may see the following error:

`error: [{"message":"Missing parameter Authorization in headers. "}]`

Changing an OpenAPI spec so the header parameter name is `authorization` eliminates this error message, demonstrating that the oas-tools is not handling headers as case-insensitive.  Inspecting oas-validator.js, there is currently no place where the header parameter name key is being lowercased to match, e.g., Express.

This pull includes a modification to the test server's OpenAPI Spec to illustrate the failure, as well as a fix to the OAS-validator.