### PR TITLE
Call registerPaths first before firing callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -424,8 +424,8 @@ var initializeMiddleware = function initializeMiddleware(specDoc, app, callback)
     swaggerUi: require('./middleware/empty_middleware'),
     swaggerSecurity: require('./middleware/empty_middleware')
   };
-  callback(middleware);
   registerPaths(fullSchema, app);
+  callback(middleware);
 };
 
 module.exports = {


### PR DESCRIPTION
Express middlewares setup in the server config not firing inside the initializeMiddleware function.

Updated **src/index.js** _initializeMiddleware_ function and called ```registerPaths``` first before ```callback```