### PR TITLE
Bugfix: OAS-Router does not work with endpoints that serve different content-types

### DIFF
--- a/src/middleware/oas-router.js
+++ b/src/middleware/oas-router.js
@@ -122,19 +122,19 @@ function checkResponse(req, res, oldSend, oasDoc, method, requestedSpecPath, con
       var mimeAccept = new MIMEtype(acceptType);
       Object.keys(responseCodeSection.content).forEach((contentType) => {
         if (!resultType) {
+          var firstMatch, secondMatch;
           var mimeContent = new MIMEtype(contentType);
+
           if (explicitType) {
-            var firstMatch = explicitType.type === mimeContent.type && (mimeAccept.type === mimeContent.type || mimeAccept.type === '*');
-            var secondMatch = explicitType.subtype === mimeContent.subtype && (mimeAccept.subtype === mimeContent.subtype || mimeAccept.subtype === '*');
-            if (firstMatch && secondMatch) {
-              resultType = explicitType;
-            }
+            firstMatch = explicitType.type === mimeContent.type && (mimeAccept.type === mimeContent.type || mimeAccept.type === '*');
+            secondMatch = explicitType.subtype === mimeContent.subtype && (mimeAccept.subtype === mimeContent.subtype || mimeAccept.subtype === '*');
           } else {
-            var firstMatch = mimeAccept.type === mimeContent.type || mimeAccept.type === '*';
-            var secondMatch = mimeAccept.subtype === mimeContent.subtype || mimeAccept.subtype === '*';
-            if (firstMatch && secondMatch) {
-              resultType = mimeContent;
-            }
+            firstMatch = mimeAccept.type === mimeContent.type || mimeAccept.type === '*';
+            secondMatch = mimeAccept.subtype === mimeContent.subtype || mimeAccept.subtype === '*';
+          }
+
+          if (firstMatch && secondMatch) {
+            resultType = mimeContent;
           }
         }
       });


### PR DESCRIPTION
**Problem description:**
The current implementation does not properly work for endpoints that serve
multiple content-types like for example an file / image endpoint that
should be able to provide different types of images to be rendered or used
by the browser or other HTML clients. Therefore the logic for setting the
correct content-type should reside in the controller. However, the current
implementation overwrites any changes made to the content-type header and
always sets it to application/json by default. Therefore the following
changes have been made to take a previously set content-type, the accepted
and available validation types into consideration.

**Our problem:**
1. Endpoint that serves files by id (e.g. images like svg, png, gif, jpeg)
2. Definition of multiple content types in the response definition (image/png, image/svg):
https://swagger.io/docs/specification/describing-responses/#media-types

**Result:**
For a client like Chrome the first matching image/* content type will be used by the oas-router. Therefore, problem will occur while rendering images. For example, when either a png file has a Content-Type of image/svg+xml or a svg file has a Content-Type of image/png. Because of that the current implementation cannot be used for endpoints that serve multiple file / content types.

**Reproduce problem:**
1. Create endpoint with two or more image media types
https://swagger.io/docs/specification/describing-responses/#media-types
2. Try to send/expose the image files with the correct content-type.
(Hint: Not impossible)
3. The oas-router cannot know the logic for setting the media type for such an endpoint. It will always pick the first media type that has a matching major type like image/...

**Solution:**
The oas-router has to be adapted to accept content-types set through logic in the controllers or services of the application and will than just validate if the set content-type will be accepted by the client and can be validated with the list of content-types defined in the OA3 specification file.