### PR TITLE
Bugfix: Wrong boolean query parameter validation

### DIFF
--- a/src/middleware/oas-validator.js
+++ b/src/middleware/oas-validator.js
@@ -329,7 +329,7 @@ function convertValue(value, schema, type) { // eslint-disable-line
         if (['false', 'true'].indexOf(value) === -1) {
           value = original; // eslint-disable-line
         } else {
-          value = value === 'true' || value; // eslint-disable-line
+          value = value === 'true'; // eslint-disable-line
         }
       }
 


### PR DESCRIPTION
**Bug description:**
Boolean query parameters are wrongly validated and casted. A query parameter set to false is evaluated as a string containing the value "false" instead of the actual boolean value false.

**Reproduce problem:**
Create a query parameter and try to set it to false and read its type. It will result in type string instead of type boolean. When set to true in the URL/query parameter the type is boolean.