### PR TITLE
response validation to validate parsed response not original source object

### DIFF
--- a/src/middleware/oas-router.js
+++ b/src/middleware/oas-router.js
@@ -159,7 +159,7 @@ function checkResponse(req, res, oldSend, oasDoc, method, requestedSpecPath, con
 
       content[0] = JSON.stringify(content[0]);
       logger.debug("Schema to use for validation: " + JSON.stringify(validSchema));
-      var err = validator.validate(data, validSchema);
+      var err = validator.validate(JSON.parse(content[0]), validSchema);
       if (err === false) {
         newErr = {
           message: "Wrong data in the response. ",


### PR DESCRIPTION
Response validation to validate parsed response rather than the response's original source object.

I am having issues that my controller returns an object with date fields, which the schema says should be strings (as is the case in a JSON representation of the object). This is causing the validation to throw errors even though the payload is valid.

This change parses the JSON response that has been created back into an object for validation, rather than validating the original object that was returned from the controller.

We start with > ControllerOutput [object]
We transform it > Response = JSON.stringify(ControllerOutput) [string]
This change proposes > ValidatedObject = JSON.parse(Response) [object]

Validation of the ControllerOutput fails. [current state]
Validation of the ValidatedObject passes. [new state]

I have no idea if this is on the right track or if I'm just doing something very wrong with my controllers returning date fields? But this fixed the issue for me so I submit it for your consideration.