### PR TITLE
Feature: Enable validation of additional properties for a request body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4261,9 +4261,9 @@
       }
     },
     "json-schema-deref-sync": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
-      "integrity": "sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.14.0.tgz",
+      "integrity": "sha512-yGR1xmhdiD6R0MSrwWcFxQzAj5b3i5Gb/mt5tvQKgFMMeNe0KZYNEN/jWr7G+xn39Azqgcvk4ZKMs8dQl8e4wA==",
       "requires": {
         "clone": "^2.1.2",
         "dag-map": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fs": "0.0.2",
     "js-yaml": "^3.13.1",
     "json-schema-deref": "^0.5.0",
-    "json-schema-deref-sync": "^0.13.0",
+    "json-schema-deref-sync": "^0.14.0",
     "jsonwebtoken": "^8.5.1",
     "lodash-compat": "^3.10.2",
     "multer": "^1.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -391,7 +391,7 @@ var initialize = function initialize(oasDoc, app, callback) {
 
   init_checks(oasDoc, callback);
 
-  var fullSchema = deref(oasDoc);
+  var fullSchema = deref(oasDoc, { mergeAdditionalProperties: true });
   logger.info("Specification file dereferenced");
 
   registerPaths(fullSchema, app);

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -1509,6 +1509,47 @@ function multipartFormTests() {
     })
 }
 
+function noAdditionalPropertiesTest() {
+    describe('/POST noAdditionalPropertiesTest', () => {
+        const successResponse = 'operation successfull'
+        const validPet = {
+            id: 4711,
+            name: 'MultipartFormdataRabbit'
+        }
+
+        it('should successfully execute POST request', (done) => {
+            chai.request(server)
+                .post('/api/v1/noAdditionalPropertiesTest')
+                .send(validPet)
+                .end((err, res) => {
+                    if (err) {
+                        done(err);
+                    }
+                    res.should.have.status(201);
+                    expect(res.body).to.have.property('message');
+                    expect(res.body.message).to.equal(successResponse)
+                    done();
+                });
+        })
+
+        it('should fail, because an additional property is part of the request', (done) => {
+            const errorMessage = 'Wrong data in the body of the request. ';
+            chai.request(server)
+                .post('/api/v1/noAdditionalPropertiesTest')
+                .send(Object.assign({anyOtherProperty: "any value"}, validPet))
+                .end((err, res) => {
+                    if (err) {
+                        done(err);
+                    }
+                    res.should.have.status(400);
+                    res.body.should.be.a('Array');
+                    res.body[0].message.should.be.equal(errorMessage);
+                    done();
+                });
+        })
+    })
+}
+
 describe('Pets', () => {
     before((done) => {
         // await for server creation
@@ -1531,4 +1572,5 @@ describe('Pets', () => {
     deleteTests();
     multipartFormTests();
     miscTests();
+    noAdditionalPropertiesTest();
 });

--- a/tests/testServer/api/oai-spec.yaml
+++ b/tests/testServer/api/oai-spec.yaml
@@ -762,6 +762,29 @@ paths:
               schema:
                 type: object
       x-router-controller: "petsController"
+  /noAdditionalPropertiesTest:
+    post:
+      summary: Test that in case of additionalProperties false, an error is returned if the request contains additional properties
+      operationId: anyResponse
+      security: []
+      tags:
+        - pets
+      requestBody:
+        description: Pet where no additional properties are allowed
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+              additionalProperties: false
+      responses:
+        "201":
+          description: Any sample response
+          content:
+            application/json:
+              schema:
+                type: object
+      x-router-controller: "petsController"
 security:
   - Bearer: []
 components:

--- a/tests/testServer/controllers/petsController.js
+++ b/tests/testServer/controllers/petsController.js
@@ -498,6 +498,12 @@ exports.defaultResponseCode = (req, res) => {
   });
 };
 
+exports.anyResponse = (req, res) => {
+  res.status(201).send({
+    message: "operation successfull"
+  })
+}
+
 exports.pets = pets;
 exports.corruptPets = corruptPets;
 exports.setCorrectPets = setCorrectPets;


### PR DESCRIPTION
**Problem description:**
The current implementation is not able to validate whether additional properties are send with a request or not.
This is the case for example setting `additionalProperties: false` in a `requestBody` of any endpoint.

**Changes in this PR**
- upgrade `json-schema-deref-sync` to version `0.14.0` in order to get this feature [json-schema-deref-sync#31](https://github.com/cvent/json-schema-deref-sync/pull/31)
- enable the `mergeAdditionalProperties` feature
- write positive and negative test
