### PR TITLE
Move snyk to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "validator": "^13.0.0",
     "whatwg-mimetype": "^2.3.0",
     "winston": "^3.2.1",
-    "z-schema": "^4.2.0",
-    "snyk": "^1.440.4"
+    "z-schema": "^4.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -49,7 +48,8 @@
     "mocha": "^7.0.1",
     "mongoose": "^5.7.5",
     "nyc": "^15.0.0",
-    "publish-please": "^5.5.2"
+    "publish-please": "^5.5.2",
+    "snyk": "^1.440.4"
   },
   "snyk": true,
   "nyc": {


### PR DESCRIPTION
This will save roundabout 32MB or 58%,
if the npm package is installed
as dependency or with production flag