### PR TITLE
fix: support jest test

### DIFF
--- a/src/entrypoint.cjs
+++ b/src/entrypoint.cjs
@@ -1,9 +1,16 @@
-const oasOld = import('./index_old.js');
+let oasOldModule;
 const oasNew = import('./index.js');
+
+function oasOld() {
+    if (!oasOldModule) {
+        oasOldModule = import('./index_old.js');
+    }
+    return oasOldModule;
+}
 
 function initialize(...args) {
     if (args.length === 3) {
-        oasOld.then((m) => m.initialize(args[0], args[1], args[2]));
+        oasOld().then((m) => m.initialize(args[0], args[1], args[2]));
     } else {
         return oasNew.then((m) => m.initialize(args[0], args[1]));
     }
@@ -14,7 +21,7 @@ function use(...args) {
 }
 
 function configure(cfg) {
-    oasOld.then((m) => m.configure(cfg));
+    oasOld().then((m) => m.configure(cfg));
 }
 
 module.exports = {


### PR DESCRIPTION
avoid parallel import() as this may trigger esm import bugs which blocks jest tests

### Initial checks

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linked an issue to this pull request? (Create one if it does not exist)
* [x] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### [ISSUE TYPE] <!-- Bug or Suggestion -->
https://github.com/oas-tools/oas-tools/issues/342

#### Description
See:
- https://github.com/oas-tools/oas-tools/issues/342
- https://github.com/nodejs/node/issues/33216
- https://github.com/kulshekhar/ts-jest/issues/3888
- https://github.com/facebook/jest/issues/11434

#### Implementation details
Perform lay loading of `./index_old.js` (oasOld). This avoid the issue with parallel imports.

To verify with jest:

````
# install jest
npm install -D jest

# add a file jest smoke test in the file: /tests/jest.test.js
import express from 'express';
import oasTools from '@oas-tools/core';
import fs from 'fs';

test("jest test", async () => {
    const app = express();
    const defaults = JSON.parse(fs.readFileSync('tests/testServer/.oastoolsrc'));

    await oasTools.initialize(app, defaults);
});

# add a jest script to package.json
"jest-test": "NODE_OPTIONS=--experimental-vm-modules jest --env=node /tests/jest.test.js",

# run test
npm run jest-test
````
