### PR TITLE
feat: support default exports for controllers

### DIFF
--- a/src/middleware/native/oas-router.js
+++ b/src/middleware/native/oas-router.js
@@ -61,9 +61,10 @@ export class OASRouter extends OASBase {
 
               if (!path) throw new errors.RoutingError(`Controller ${opControllerName} not found`);
 
+              const controller = await import(pathToFileURL(path));
               tmp[expressPath] = {
                 ...tmp[expressPath],
-                [method.toUpperCase()]: (await import(pathToFileURL(path)))[opId]
+                [method.toUpperCase()]: controller[opId] ?? controller.default?.[opId]
               };
 
               if (!tmp[expressPath][method.toUpperCase()])

--- a/tests/suites/router.test.js
+++ b/tests/suites/router.test.js
@@ -45,7 +45,7 @@ export default () => {
                     assert.equal(res.data, 'Test service for router middleware');
                 });
             });
-            
+
             it('Should route to controller correctly when controller is async and fail if an error is thrown', async () => {
                 cfg.useAnnotations = false;
                 cfg.logger.level = 'off';
@@ -57,6 +57,16 @@ export default () => {
                     assert.equal(err.response.status, 500);
                     assert.deepStrictEqual(err.response.data, {error: "Error: Error raised in async controller"});
                 });
+            });
+
+            it('Should route to controller correctly when controller uses default exports', async () => {
+              cfg.useAnnotations = false;
+              await init(cfg);
+              
+              await axios.get('http://localhost:8080/api/v1/oasRouter/defaultexport').then(res => {
+                  assert.equal(res.status, 200);
+                  assert.equal(res.data, 'Test service for router middleware');
+              });
             });
         });
     });

--- a/tests/testServer/api/3.0.yaml
+++ b/tests/testServer/api/3.0.yaml
@@ -169,6 +169,12 @@ paths:
       x-router-controller: oasRouterTestController
       responses:
         '500': {$ref: 'subschemas/responses.yaml#/500'}
+  /api/v1/oasRouter/defaultexport: 
+    get:
+      operationId: getRequest
+      x-router-controller: oasRouterDefaultExportTestController
+      responses:
+        '500': {$ref: 'subschemas/responses.yaml#/500'}
 
   # OAS RESPONSE VALIDATOR TEST ENDPOINT
   /api/v1/oasResponseValidator:

--- a/tests/testServer/controllers/oasRouterDefaultExportTestController.js
+++ b/tests/testServer/controllers/oasRouterDefaultExportTestController.js
@@ -1,0 +1,12 @@
+/** @oastools {Controller} /api/v1/oasRouter */
+import * as service from './oasRouterTestService.js';
+
+
+export default {
+  /**
+   * @oastools {method} GET
+   */
+  getRequest(req, res, next) {
+    service.getRequest(req, res, next);
+  },
+}


### PR DESCRIPTION
### Initial checks

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linked an issue to this pull request? (Create one if it does not exist)
* [x] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### [SUGGESTION]

#### Description
Support default exports in controllers [#372](https://github.com/oas-tools/oas-tools/issues/372)

#### Implementation details
Implemented in `src/middleware/native/oas-router.js`
Basically if method is not found, try to look for it in `default` property
Added associated test

