### PR TITLE
feat: use custom handler if defined

### DIFF
--- a/src/middleware/native/oas-error.js
+++ b/src/middleware/native/oas-error.js
@@ -42,7 +42,9 @@ export class OASErrorHandler extends OASBase {
         sendErr(401);
       } else if (err.name === "AuthError") {
         sendErr(403);
-      } else if (config.customHandler) {
+      }
+      
+      if (config.customHandler) {
         config.customHandler(err, sendErr);
       }
 


### PR DESCRIPTION
### Initial checks

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linked an issue to this pull request? (Create one if it does not exist)
* [x] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### [BUG]

#### Description
Use custom error handler if provided [#374](https://github.com/oas-tools/oas-tools/issues/374)

#### Implementation details
Implemented in `src/middleware/native/oas-error.js`
Basically if custom error handler is provided, use it
