### PR TITLE
feat: throw RequestValidationError on invalid JSON in query parameter

### DIFF
--- a/src/middleware/native/oas-params.js
+++ b/src/middleware/native/oas-params.js
@@ -1,6 +1,8 @@
 import _ from "lodash";
-import { schema } from "../../utils/index.js";
-import { OASBase, logger } from "@oas-tools/commons";
+import { schema, commons } from "../../utils/index.js";
+import { OASBase, logger, errors } from "@oas-tools/commons";
+
+const { RequestValidationError } = errors;
 
 export class OASParams extends OASBase {
 
@@ -126,7 +128,11 @@ function _parseValue(val, paramDefinition, schema, type) {
             if (paramDefinition.content) {
                 const contentType = Object.keys(paramDefinition.content)[0];
                 if (contentType.toLocaleLowerCase() === "application/json") {
-                    return JSON.parse(val);   
+                    try {
+                        return JSON.parse(val);   
+                    } catch {
+                        commons.handle(RequestValidationError, `Invalid JSON in parameter '${paramDefinition.name}'.`, true);
+                    }
                 } else {
                     logger.warn(`Content type ${contentType} is not supported. Raw value will be returned.`);
                     return val

--- a/src/middleware/native/oas-params.js
+++ b/src/middleware/native/oas-params.js
@@ -132,6 +132,7 @@ function _parseValue(val, paramDefinition, schema, type) {
                         return JSON.parse(val);   
                     } catch {
                         commons.handle(RequestValidationError, `Invalid JSON in parameter '${paramDefinition.name}'.`, true);
+                        break;
                     }
                 } else {
                     logger.warn(`Content type ${contentType} is not supported. Raw value will be returned.`);

--- a/tests/testServer/api/3.0.yaml
+++ b/tests/testServer/api/3.0.yaml
@@ -30,6 +30,14 @@ paths:
         - $ref: 'subschemas/oasparams.yaml#/explode/cookieparams/0'
       responses:
         '200': {$ref: 'subschemas/responses.yaml#/200'}
+  /api/v1/oasParams/json:
+    x-router-controller: oasParamsTestController
+    get:
+      operationId: getRequest
+      parameters:
+        - $ref: 'subschemas/oasparams.yaml#/json/queryparams/0'
+      responses:
+        '200': {$ref: 'subschemas/responses.yaml#/200'}
   /api/v1/oasParams/{testparamsimple}/{testparamslabel}/{testparamsmatrix}:
     x-router-controller: oasParamsTestController
     get:

--- a/tests/testServer/api/subschemas/oasparams.yaml
+++ b/tests/testServer/api/subschemas/oasparams.yaml
@@ -136,6 +136,21 @@ explode:
       schema:
         type: array
 
+json:
+  queryparams:
+    - name: queryparamjson
+      description: query parameter content application/json
+      in: query
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              otherkey:
+                type: string
+
 body:
   schemaWithDefaults:
     type: array

--- a/tests/testServer/controllers/oasParamsTestController.js
+++ b/tests/testServer/controllers/oasParamsTestController.js
@@ -19,6 +19,14 @@ export function getRequestExplode(req, res, next) {
 
 /**
  * @oastools {method} GET
+ * @oastools {path} /json
+ */
+export function getRequestJson(req, res, next) {
+  service.getRequest(req.params, res, next);
+}
+
+/**
+ * @oastools {method} GET
  * @oastools {path} /explode/{testparamsimple}/{testparamslabel}/{testparamsmatrix}
  * @oastools {path} /{testparamsimple}/{testparamslabel}/{testparamsmatrix}
  */


### PR DESCRIPTION
### Initial checks

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linked an issue to this pull request? (Create one if it does not exist)
* [x] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### [BUG] (or could be a suggestion, depends on interpretation)

#### Description
When sending a request containing parameters with invalid JSON, oas-tools throws an Internal Server Error due to a JSON syntax error (e.g. `unexpected }` or `unexpected ,` or `unexpected end of JSON` etc.) instead of Status 400 / Bad Request.
Issue: #381 

#### Implementation details
Wrapped JSON.parse() in the oas-params.js middleware in a try/catch block, now throws a RequestValidationError on invalid JSON (instead of an Internal Server Error due to JSON syntax errors).

