### PR TITLE
feat: changed order of error handler if tree, to prioritize the customHandler

### DIFF
--- a/src/middleware/native/oas-error.js
+++ b/src/middleware/native/oas-error.js
@@ -32,7 +32,9 @@ export class OASErrorHandler extends OASBase {
       }
 
       /* Handle errors */
-      if (err.name === "RequestValidationError") {
+      if (config.customHandler) {
+        config.customHandler(err, sendErr);
+      } else if (err.name === "RequestValidationError") {
         if ((/[\S\s]* content-type is not accepted [\S\s]*/).test(err.message)) {
           sendErr(406);
         } else {
@@ -42,8 +44,6 @@ export class OASErrorHandler extends OASBase {
         sendErr(401);
       } else if (err.name === "AuthError") {
         sendErr(403);
-      } else if (config.customHandler) {
-        config.customHandler(err, sendErr);
       }
 
       /* Catch unhandled errors */


### PR DESCRIPTION
### Initial checks

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linked an issue to this pull request? (Create one if it does not exist)
* [x] Have you used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format?

### [ISSUE TYPE] BUG
https://github.com/oas-tools/oas-tools/issues/384

#### Description
When implementing a custom error handler, the errors 'RequestValidationError', 'SecurityError' and 'AuthError' still use the default handler, because they are higher in the if tree.

#### Implementation details
Simply reordered the if tree, so the custom error handler takes priority.
